### PR TITLE
Add support for Alibaba Cloud Linux

### DIFF
--- a/tasks/alibaba/install.yml
+++ b/tasks/alibaba/install.yml
@@ -1,0 +1,22 @@
+---
+- name: Alibaba Cloud Linux 3 | DNF Dependencies
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ tailscale_yum_dependencies }}"
+    state: present
+    use_backend: dnf4
+
+- name: Alibaba Cloud Linux 3 | Add Tailscale Repo
+  become: true
+  ansible.builtin.command: dnf config-manager --add-repo {{ tailscale_yum_repos[ansible_distribution] }}
+  args:
+    creates: /etc/yum.repos.d/tailscale.repo
+  register: add_tailscale_repo
+
+- name: Alibaba Cloud Linux 3 | Install Tailscale
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ tailscale_package }}"
+    update_cache: '{{ add_tailscale_repo.changed | default(false) | bool }}'
+    state: '{{ state }}'
+    use_backend: dnf4

--- a/tasks/alibaba/uninstall.yml
+++ b/tasks/alibaba/uninstall.yml
@@ -1,0 +1,25 @@
+---
+- name: Alibaba Cloud Linux 3 | Remove Tailscale
+  become: true
+  ansible.builtin.dnf:
+    name: "{{ tailscale_package }}"
+    state: absent
+    use_backend: dnf4
+
+# noqa command-instead-of-module
+- name: Alibaba Cloud Linux 3 | Check for Tailscale Repo
+  ansible.builtin.shell: |
+    set -o pipefail
+    dnf repolist | grep tailscale
+  register: repolist_tailscale
+  changed_when: false
+  failed_when:
+    - repolist_tailscale.rc != 0
+    - repolist_tailscale.rc != 1
+
+- name: Alibaba Cloud Linux 3 | Remove Tailscale Repo
+  become: true
+  ansible.builtin.command: dnf config-manager --disable tailscale-{{ release_stability | lower }}
+  register: dnf_config_output
+  changed_when: dnf_config_output.rc != 0
+  when: repolist_tailscale.rc != 1

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,10 @@
     or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
   ansible.builtin.include_tasks: fedora/install.yml
 
+- name: Install | Alibaba Cloud Linux
+  when: ansible_distribution == 'Alibaba' and ansible_distribution_major_version | int >= 3
+  ansible.builtin.include_tasks: alibaba/install.yml
+
 - name: Install | Arch
   when: ansible_distribution == 'Archlinux'
   ansible.builtin.include_tasks: arch/install.yml

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -54,6 +54,10 @@
     or (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int >= 2023)
   ansible.builtin.include_tasks: fedora/uninstall.yml
 
+- name: Uninstall | Alibaba Cloud Linux
+  when: ansible_distribution == 'Alibaba' and ansible_distribution_major_version | int >= 3
+  ansible.builtin.include_tasks: alibaba/uninstall.yml
+
 - name: Uninstall | Arch
   when: ansible_distribution == 'Archlinux'
   ansible.builtin.include_tasks: arch/uninstall.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -54,6 +54,7 @@ tailscale_yum_repos:
   OracleLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
   Rocky: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
   AlmaLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
+  Alibaba: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/8/tailscale.repo
 
 tailscale_dnf_dependencies:
   - python-dnf


### PR DESCRIPTION
The installation process for Tailscale on Alibaba Cloud Linux 3 is similar to the one used for Amazon Linux 2023. Unfortunately newer versions of ansible identify "yum" as the package manager for this OS, which makes the `ansible.builtin.dnf` module request a `use_backend` parameter. Using a newer version of ansible doesn't fix the problem either for [unrelated reasons](https://www.jeffgeerling.com/blog/2024/newer-versions-ansible-dont-work-rhel-8).

I've created different install/uninstall steps specific to Alibaba Cloud Linux 3, which are almost identical to the "CentOS and related families" tasks. Difference being the `use_backend` param for the dnf module.

Tailscale doesn't provide specific repo packages for Alibaba Cloud Linux, so the repo path is the same as CentOS 8, which what this OS is based on.